### PR TITLE
set version & add window validation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,10 +2,10 @@ exports.report = report;
 exports.initialize = initialize;
 exports.createReport = createReport;
 
-var myVersion = "0.0.6"; // should match package.json
+var myVersion = "0.0.11"; // should match package.json
 var initialized = false;
+
 var uuidArray = new Uint8Array(16);
-var crypto = window.crypto || window.msCrypto;
 var pageStartTime = new Date();
 var stackLineRe = /\s+at (.+) \((.+):(\d+):(\d+)\)/;
 
@@ -18,6 +18,7 @@ var userAttributes;
 var contextLineCount;
 var filter;
 var sampling;
+var crypto;
 
 function report(err, attributes, callback) {
   var report = createReport();
@@ -26,7 +27,30 @@ function report(err, attributes, callback) {
   report.send(callback);
 }
 
+function validateWindow() {
+  try {
+    window;
+    window.crypto || window.msCrypto;
+    window.addEventListener;
+    XMLHttpRequest;
+  } catch (e) {
+    console.error(
+      new Error(
+        [
+          e.message || "",
+          "Backtrace-JS requires a standard web-browser window object.",
+          "Consider Backtrace-Node for non web-browser based javascript applications"
+        ].join("\n")
+      ).stack
+    );
+    return false;
+  }
+  return true;
+}
+
 function initialize(options) {
+  if (!validateWindow()) return;
+
   options = options || {};
 
   debugBacktrace = !!options.debugBacktrace;
@@ -37,6 +61,8 @@ function initialize(options) {
   sampling = options.sampling;
   userAttributes = extend({}, options.attributes || {});
   contextLineCount = options.contextLineCount || 200;
+
+  crypto = window.crypto || window.msCrypto;
 
   var disableGlobalHandler = !!options.disableGlobalHandler;
   var handlePromises = !!options.handlePromises;
@@ -93,8 +119,8 @@ function BacktraceReport() {
       {
         "process.age": getUptime(),
         "user.agent": navigator.userAgent,
-        "hostname":  window.location && window.location.hostname,
-        "referer":  window.location && window.location.href
+        hostname: window.location && window.location.hostname,
+        referer: window.location && window.location.href
       },
       userAttributes
     ),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backtrace-js",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Backtrace.io error reporting tool for client-side applications",
   "main": "lib/index.js",
   "author": "Backtrace <team@backtrace.io>",


### PR DESCRIPTION
This PR sets version to match package.json & adds a validation for the window on initialization.

window based objects/functions are moved to initialize or after so to allow this validation to be the consistent error point.  