### PR TITLE
Add session id to metrics submission attributes.

### DIFF
--- a/source/backtraceClient.ts
+++ b/source/backtraceClient.ts
@@ -324,7 +324,7 @@ export class BacktraceClient {
       'window.screenY': window.screenY,
       'window.screenLeft': window.screenLeft,
       'window.screenTop': window.screenTop,
-      'application.version': __VERSION__,
+      'backtrace.version': __VERSION__,
       guid: getBacktraceGUID(),
     };
   }

--- a/source/backtraceClient.ts
+++ b/source/backtraceClient.ts
@@ -290,7 +290,7 @@ export class BacktraceClient {
   private readAttributes(): { [index: string]: any } {
     const browserName = getBrowserName();
     return {
-      application: document.title,
+      application: document.title || 'unknown', // application is required. Using unknown string if it is not found.
       'process.age': Math.floor(
         (new Date().getTime() - pageStartTime.getTime()) / 1000,
       ),

--- a/source/backtraceClient.ts
+++ b/source/backtraceClient.ts
@@ -324,7 +324,7 @@ export class BacktraceClient {
       'window.screenY': window.screenY,
       'window.screenLeft': window.screenLeft,
       'window.screenTop': window.screenTop,
-      'backtrace.version': __VERSION__,
+      'application.version': __VERSION__,
       guid: getBacktraceGUID(),
     };
   }

--- a/source/model/backtraceMetrics.ts
+++ b/source/model/backtraceMetrics.ts
@@ -158,7 +158,7 @@ export class BacktraceMetrics {
       [index: string]: any;
     };
     const result: { [index: string]: string } = {
-      'application.session': this.sessionId || ''
+      'application.session': this.sessionId as string
     };
 
     for (const attributeName in clientAttributes) {

--- a/source/model/backtraceMetrics.ts
+++ b/source/model/backtraceMetrics.ts
@@ -1,6 +1,5 @@
 import { BacktraceClientOptions } from '..';
 import { SEC_TO_MILLIS } from '../consts';
-import { APP_NAME, USER_AGENT, VERSION } from '../consts/application';
 import { currentTimestamp, getEndpointParams, post, uuid } from '../utils';
 
 /**
@@ -15,8 +14,6 @@ export class BacktraceMetrics {
   private readonly heartbeatInterval: number = 60000; // One minutes in milliseconds.
 
   private readonly timestamp = currentTimestamp();
-  private readonly applicationName: string = '';
-  private readonly applicationVersion: string = '';
 
   private summedEndpoint: string;
   private uniqueEndpoint: string;
@@ -61,13 +58,6 @@ export class BacktraceMetrics {
 
     this.summedEndpoint = `${this.hostname}/api/summed-events/submit?universe=${this.universe}&token=${this.token}`;
     this.uniqueEndpoint = `${this.hostname}/api/unique-events/submit?universe=${this.universe}&token=${this.token}`;
-
-    // get application name from attributes.
-    this.applicationName = this.getEventAttributes()?.application || '';
-    // application version is not well defined for simple browser/js apps.
-    // if application.version is provided in attributes, use it.
-    this.applicationName =
-      this.getEventAttributes()?.['application.version'] || '';
 
     // Get current sessionId. If it is not defined, create new session and "Launch Application"
     const currentSessionId = this.getSessionId();
@@ -119,9 +109,11 @@ export class BacktraceMetrics {
    * Send POST to unique-events API endpoint
    */
   public async sendUniqueEvent(): Promise<void> {
+    const attributes = this.getEventAttributes();
+
     const payload = {
-      application: this.applicationName,
-      appversion: this.applicationVersion,
+      application: attributes.application || '',
+      appversion: attributes['application.version'] || '',
       metadata: {
         dropped_events: 0,
       },
@@ -141,9 +133,11 @@ export class BacktraceMetrics {
    * Send POST to summed-events API endpoint
    */
   public async sendSummedEvent(metricGroup: string): Promise<void> {
+    const attributes = this.getEventAttributes();
+
     const payload = {
-      application: this.applicationName,
-      appversion: this.applicationVersion,
+      application: attributes.application || '',
+      appversion: attributes['application.version'] || '',
       metadata: {
         dropped_events: 0,
       },

--- a/source/model/backtraceMetrics.ts
+++ b/source/model/backtraceMetrics.ts
@@ -112,8 +112,8 @@ export class BacktraceMetrics {
     const attributes = this.getEventAttributes();
 
     const payload = {
-      application: attributes.application || '',
-      appversion: attributes['application.version'] || '',
+      application: attributes.application || 'unknown',
+      appversion: attributes['application.version'] || 'unknown',
       metadata: {
         dropped_events: 0,
       },

--- a/source/model/backtraceMetrics.ts
+++ b/source/model/backtraceMetrics.ts
@@ -112,8 +112,8 @@ export class BacktraceMetrics {
     const attributes = this.getEventAttributes();
 
     const payload = {
-      application: attributes.application || 'unknown',
-      appversion: attributes['application.version'] || 'unknown',
+      application: attributes.application,
+      appversion: attributes['application.version'],
       metadata: {
         dropped_events: 0,
       },
@@ -136,8 +136,8 @@ export class BacktraceMetrics {
     const attributes = this.getEventAttributes();
 
     const payload = {
-      application: attributes.application || '',
-      appversion: attributes['application.version'] || '',
+      application: attributes.application,
+      appversion: attributes['application.version'],
       metadata: {
         dropped_events: 0,
       },
@@ -159,6 +159,7 @@ export class BacktraceMetrics {
     };
     const result: { [index: string]: string } = {
       'application.session': this.sessionId,
+      'application.version': 'unknown', // This will be overwritten if application.version is provided in clientAtrributes.
     };
 
     for (const attributeName in clientAttributes) {

--- a/source/model/backtraceMetrics.ts
+++ b/source/model/backtraceMetrics.ts
@@ -15,9 +15,8 @@ export class BacktraceMetrics {
   private readonly heartbeatInterval: number = 60000; // One minutes in milliseconds.
 
   private readonly timestamp = currentTimestamp();
-  private readonly userAgent = USER_AGENT;
-  private readonly applicationName = APP_NAME;
-  private readonly applicationVersion = VERSION;
+  private readonly applicationName: string = '';
+  private readonly applicationVersion: string = '';
 
   private summedEndpoint: string;
   private uniqueEndpoint: string;
@@ -62,6 +61,13 @@ export class BacktraceMetrics {
 
     this.summedEndpoint = `${this.hostname}/api/summed-events/submit?universe=${this.universe}&token=${this.token}`;
     this.uniqueEndpoint = `${this.hostname}/api/unique-events/submit?universe=${this.universe}&token=${this.token}`;
+
+    // get application name from attributes.
+    this.applicationName = this.getEventAttributes()?.application || '';
+    // application version is not well defined for simple browser/js apps.
+    // if application.version is provided in attributes, use it.
+    this.applicationName =
+      this.getEventAttributes()?.['application.version'] || '';
 
     // Get current sessionId. If it is not defined, create new session and "Launch Application"
     const currentSessionId = this.getSessionId();

--- a/source/model/backtraceMetrics.ts
+++ b/source/model/backtraceMetrics.ts
@@ -157,7 +157,9 @@ export class BacktraceMetrics {
     const clientAttributes = this.attributeProvider() as {
       [index: string]: any;
     };
-    const result: { [index: string]: string } = {};
+    const result: { [index: string]: string } = {
+      'application.session': this.sessionId || ''
+    };
 
     for (const attributeName in clientAttributes) {
       if (
@@ -202,26 +204,10 @@ export class BacktraceMetrics {
   }
 
   /**
-   * Get stored time since last session created or current time
-   */
-  private getSessionStart(): number | undefined {
-    const sessionStartStr = localStorage.getItem('sessionStart');
-    return sessionStartStr ? parseInt(sessionStartStr, 10) : undefined;
-  }
-
-  /**
    * Get stored time since last page navigation or current time
    */
   private getLastActive(): number | undefined {
     const lastActiveStr = localStorage.getItem('lastActive');
-    return lastActiveStr ? parseInt(lastActiveStr, 10) : undefined;
-  }
-
-  /**
-   * Get stored session active interval id.
-   */
-  private getActiveSessionIntervalId(): number | undefined {
-    const lastActiveStr = localStorage.getItem('activeSessionIntervalId');
     return lastActiveStr ? parseInt(lastActiveStr, 10) : undefined;
   }
 


### PR DESCRIPTION
The "application.session" field is required in session metrics submission as shown in the [RFC](https://docs.google.com/document/d/1_fCK4NHFiCjb4JmaO_R5drX8L4_OQhSneIuBdQ2z7Hs/edit#heading=h.7b32yhkhcc49)

In addition, the correct values for application (name) and application.version are now being used.

This field was accidentally removed in the refactoring of attributes. This change adds it back, and removes some unused functions in the BacktraceMetrics model.